### PR TITLE
Switched oauth from a browser-based flow to a command line flow.

### DIFF
--- a/src/main/scala/com/google/cloud/genomics/Client.scala
+++ b/src/main/scala/com/google/cloud/genomics/Client.scala
@@ -17,7 +17,7 @@ package com.google.cloud.genomics
 
 import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.extensions.java6.auth.oauth2.AuthorizationCodeInstalledApp
-import com.google.api.client.extensions.jetty.auth.oauth2.LocalServerReceiver
+import com.google.api.client.googleapis.extensions.java6.auth.oauth2.GooglePromptReceiver
 import com.google.api.client.googleapis.auth.oauth2.GoogleAuthorizationCodeFlow
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
@@ -50,7 +50,7 @@ object Client {
       httpTransport, jsonFactory, secrets,
       Arrays.asList(DevStorageScope, GenomicsScope, EmailScope)).setDataStoreFactory(dataStoreFactory).build()
 
-    val credential = new AuthorizationCodeInstalledApp(flow, new LocalServerReceiver()).authorize("user")
+    val credential = new AuthorizationCodeInstalledApp(flow, new GooglePromptReceiver()).authorize("user")
 
     val service = new Genomics.Builder(httpTransport, jsonFactory, credential)
       .setApplicationName(applicationName)


### PR DESCRIPTION
Small change to switch oauth from a browser-based flow to a command line flow.

Very nice spark examples against the Reads API!  I especially liked the example comparing tumor to normal reads from the synthetic data for the [DREAM SMC challenge](https://www.synapse.org/#!Synapse:syn312572/wiki/).  Had no trouble running them end to end on a Google Compute Engine instance.  Have not yet tried them in a Spark cluster scenario.
