### PR TITLE
Updated ReadsIterator to the ReadBuilding pattern.

### DIFF
--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsIterator.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsIterator.scala
@@ -36,7 +36,7 @@ class ReadsIterator(service: Genomics, part: ReadsPartition) extends Iterator[(R
   // If the query data is exhausted (i.e. no more pages) the iterator will be empty.
   private def refresh(): Iterator[ReadModel] = {
     token.map { t =>
-      var req = new SearchReadsRequest()
+      val req = new SearchReadsRequest()
         .setReadsetIds(part.readsets)
         .setSequenceName(part.sequence)
         .setSequenceStart(java.math.BigInteger.valueOf(part.start))
@@ -71,22 +71,6 @@ class ReadsIterator(service: Genomics, part: ReadsPartition) extends Iterator[(R
 
   override def next(): (ReadKey, Read) = {
     val r = it.next()
-    (ReadKey(r.getReferenceSequenceName, r.getPosition.toLong),
-      Read(Map[String, Any](
-        ("alignedBases" -> r.getAlignedBases),
-        ("baseQuality" -> r.getBaseQuality),
-        ("cigar" -> r.getCigar),
-        ("flags" -> r.getFlags),
-        ("id" -> r.getId),
-        ("mappingQuality" -> r.getMappingQuality),
-        ("matePosition" -> r.getMatePosition),
-        ("mateReferenceSequenceName" -> r.getMateReferenceSequenceName),
-        ("name" -> r.getName),
-        ("originalBases" -> r.getOriginalBases),
-        ("position" -> r.getPosition),
-        ("readsetId" -> r.getReadsetId),
-        ("referenceSequenceName" -> r.getReferenceSequenceName),
-        ("tags" -> r.getTags.toMap),
-        ("templateLength" -> r.getTemplateLength))))
+    ReadBuilder.fromJavaRead(r)
   }
 }

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
@@ -46,14 +46,14 @@ case class Call(callsetId: String, callsetName: String, genotype: List[Integer],
 case class Variant(contig: String, id: String, names: Option[List[String]], 
     position: Long, end: Option[String], referenceBases: String, 
     alternateBases: Option[List[String]], info: Map[String, JList[String]], 
-    created: Long, datasetId: String, calls: Seq[Call]) extends Serializable
+    created: Long, datasetId: String, calls: Option[Seq[Call]]) extends Serializable
 
 object VariantBuilder {
   def fromJavaVariant(r: VariantModel) = {
     val variantKey = VariantKey(r.getContig, r.getPosition.toLong)
 
     val calls = if (r.containsKey("calls"))
-        r.getCalls().map(
+        Some(r.getCalls().map(
             c => Call(
                 c.getCallsetId, 
                 c.getCallsetName, 
@@ -63,9 +63,9 @@ object VariantBuilder {
                 else
                   None,
                 c.getPhaseset,
-                r.getInfo.toMap))
+                r.getInfo.toMap)))
       else
-	      null
+	      None
 
     val variant = Variant(
         r.getContig, 
@@ -77,12 +77,12 @@ object VariantBuilder {
         if (r.containsKey("end")) 
           Some(r.get("end").asInstanceOf[String]) 
         else 
-          null, 
+          None, 
         r.getReferenceBases,
         if (r.containsKey("alternateBases")) 
           Some(r.getAlternateBases.toList) 
         else 
-          null,
+          None,
         r.getInfo.toMap, 
         if (r.containsKey("created")) r.getCreated else 0L,
         r.getDatasetId,


### PR DESCRIPTION
Consolidated Java API objects transformation into the serializable objects on a ReadBuilder object.

This adds type safety as the values are no longer transformed into a Map, the class constructor is invoked directly using the appropriate types.
