### PR TITLE
Upgraded to v1beta2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,11 +5,11 @@ version := "1.0"
 scalaVersion := "2.10.4"
 
 val googleAPIVersion = "1.19.0"
-val googleAPIGenomicsVersion = "v1beta-rev34-1.19.0"
+val googleAPIGenomicsVersion = "v1beta2-rev3-1.19.0"
 
 val sparkVersion = "1.1.0"
 
-val genomicsUtilsVersion = "0.16"
+val genomicsUtilsVersion = "v1beta2-0.12"
 
 val excludeMortbayJetty = ExclusionRule(organization = "org.mortbay.jetty", name = "servlet-api")
 

--- a/src/main/scala/com/google/cloud/genomics/Client.scala
+++ b/src/main/scala/com/google/cloud/genomics/Client.scala
@@ -35,7 +35,8 @@ class Auth(val clientSecrets: String,
     val refreshToken: String) extends Serializable
 
 object Authentication {
-  def getAccessToken(applicationName: String, clientSecretsFile: String) = {
+  def getAccessToken(clientSecretsFile: String,
+      applicationName: String = "spark-examples") = {
     val verificationCodeReceiver = Suppliers.ofInstance(new GooglePromptReceiver())
     val factory = GenomicsFactory.builder(applicationName)
       .setVerificationCodeReceiver(verificationCodeReceiver).build()
@@ -63,7 +64,7 @@ object Client {
         .setRefreshToken(auth.refreshToken);
   }
 
-  def apply(applicationName: String, auth: Auth): Client = {
+  def apply(auth: Auth, applicationName: String = "spark-examples"): Client = {
     // An IOException can occur when multiple workers on the same machine try to
     // create the directory to hold the stored credentials.
     val factory = Try(GenomicsFactory.builder(applicationName)

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
@@ -30,7 +30,6 @@ class GenomicsConf(arguments: Seq[String]) extends ScallopConf(arguments) {
       descr = "Set it to a " +
       "number greater than the number of cores, to achieve maximum " +
       "throughput.")
-  val numRetries = opt[Int](default = Some(3))
   val outputPath = opt[String]()
   val partitionsPerReference = opt[Int](default = Some(10),
       descr = "How many partitions per reference. Set it to a " +
@@ -56,10 +55,6 @@ class GenomicsConf(arguments: Seq[String]) extends ScallopConf(arguments) {
       .setJars(jarPath)
     conf.set("spark.shuffle.consolidateFiles", "true")
     new SparkContext(conf)
-  }
-
-  def newGenomicsClient(application: String, auth: Auth) = {
-    Client(application, auth).genomics
   }
 
   def getReferences = {

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/SearchVariantsExample.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/SearchVariantsExample.scala
@@ -43,14 +43,12 @@ object SearchVariantsExampleKlotho {
     val sc = conf.newSparkContext(applicationName)
     Logger.getLogger("org").setLevel(Level.WARN)
     val klotho = Map(("chr13" -> (33628137L, 33628138L)))
-    val accessToken = Authentication.getAccessToken(applicationName,
-      conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
     val data = new VariantsRDD(sc,
       applicationName,
       accessToken,
       GoogleGenomicsPublicData.Platinum_Genomes,
-      new VariantsPartitioner(klotho, FixedContigSplits(1)),
-      conf.numRetries())
+      new VariantsPartitioner(klotho, FixedContigSplits(1)))
     data.cache()  // The amount of data is small since its just for one SNP.
     println("We have " + data.count() + " records that overlap Klotho.")
     println("But only " + data.filter { kv =>
@@ -93,14 +91,12 @@ object SearchVariantsExampleBRCA1 {
     val sc = conf.newSparkContext(applicationName)
     Logger.getLogger("org").setLevel(Level.WARN)
     val brca1 = Map(("chr17" -> (41196311L, 41277499L)))
-    val accessToken = Authentication.getAccessToken(applicationName,
-      conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
     val data = new VariantsRDD(sc,
         this.getClass.getName,
         accessToken,
         GoogleGenomicsPublicData.Platinum_Genomes,
-        new VariantsPartitioner(brca1, FixedContigSplits(1)),
-        conf.numRetries())
+        new VariantsPartitioner(brca1, FixedContigSplits(1)))
     data.cache() // The amount of data is small since its just for one gene
     println("We have " + data.count() + " records that overlap BRCA1.")
     println("But only " + data.filter { kv =>

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsPca.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsPca.scala
@@ -34,6 +34,7 @@ import com.google.cloud.genomics.spark.examples.rdd.VariantsPartitioner
 import com.google.cloud.genomics.spark.examples.rdd.VariantsRDD
 import com.google.cloud.genomics.utils.Paginator
 import com.google.cloud.genomics.Authentication
+import com.google.cloud.genomics.Client
 
 object VariantsPcaDriver {
 
@@ -55,11 +56,10 @@ class VariantsPcaDriver(conf: PcaConf) {
 
   val applicationName = this.getClass.getName
   val sc = conf.newSparkContext(this.getClass.getName)
-  val auth = Authentication.getAccessToken(applicationName,
-    conf.clientSecrets())
+  val auth = Authentication.getAccessToken(conf.clientSecrets())
 
   val indexes: Map[String, Int] = {
-    val client = conf.newGenomicsClient(applicationName, auth)
+    val client = Client(auth).genomics
     val searchCallsets = Paginator.Callsets.create(client)
     val req = new SearchCallSetsRequest()
         .setVariantSetIds(List(conf.variantSetId()))
@@ -75,8 +75,7 @@ class VariantsPcaDriver(conf: PcaConf) {
       new VariantsRDD(sc, this.getClass.getName, auth,
         conf.variantSetId(),
         new VariantsPartitioner(contigs,
-            FixedContigSplits(conf.partitionsPerReference())),
-        conf.numRetries())
+            FixedContigSplits(conf.partitionsPerReference())))
     }
   }
 

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
@@ -16,20 +16,17 @@ limitations under the License.
 package com.google.cloud.genomics.spark.examples.rdd
 
 import java.util.{List => JList}
-
 import scala.collection.JavaConversions._
-
 import org.apache.spark.Partition
 import org.apache.spark.SparkContext
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
-
 import com.google.api.services.genomics.model.{Read => ReadModel}
 import com.google.api.services.genomics.model.SearchReadsRequest
 import com.google.cloud.genomics.Auth
 import com.google.cloud.genomics.Client
 import com.google.cloud.genomics.utils.Paginator
-import com.google.cloud.genomics.utils.RetryPolicy
+import com.google.api.services.genomics.model.CigarUnit
 
 /**
  * A serializable version of the Read.
@@ -37,34 +34,53 @@ import com.google.cloud.genomics.utils.RetryPolicy
  * see https://code.google.com/p/google-api-java-client/issues/detail?id=390
  * for more information.
  */
-case class Read(alignedBases: String, baseQuality: String, cigar: String,
-    flags: Int, id: String, mappingQuality: Int, matePosition: Option[Int],
-    mateReferenceSequenceName: String, name: String, originalBases: String,
-    position: Int, readsetId: String, referenceSequenceName: String,
-    tags: Map[String, JList[String]], templateLength: Int) extends Serializable
+case class Read(alignedQuality: JList[Integer], cigar: String,
+    id: String, mappingQuality: Int, matePosition: Option[Long],
+    mateReferenceName: Option[String], fragmentName: String, alignedSequence: String,
+    position: Long, readGroupSetId: String, referenceName: String,
+    info: Map[String, JList[String]], fragmentLength: Int) extends Serializable
 
 object ReadBuilder {
-  def fromJavaRead(r: ReadModel) = {
-    val readKey = ReadKey(r.getReferenceSequenceName, r.getPosition.toLong)
 
-    val read = Read(r.getAlignedBases,
-        r.getBaseQuality,
-        r.getCigar,
-        r.getFlags,
+  val CIGAR_MATCH = Map(
+      "ALIGNMENT_MATCH" -> "M",
+      "CLIP_HARD" -> "H",
+      "CLIP_SOFT" -> "S",
+      "DELETE" -> "D",
+      "INSERT" -> "I",
+      "PAD" -> "P",
+      "SEQUENCE_MATCH" -> "=",
+      "SEQUENCE_MISMATCH" -> "X",
+      "SKIP" -> "N")
+
+  def fromJavaRead(r: ReadModel) = {
+    val readKey = ReadKey(r.getAlignment.getPosition.getReferenceName,
+        r.getAlignment.getPosition.getPosition)
+
+   val cigar =  r.getAlignment.getCigar.map(cigarUnit =>
+     cigarUnit.getOperationLength() +
+     CIGAR_MATCH(cigarUnit.getOperation())).mkString("")
+
+    val read = Read(
+        r.getAlignedQuality,
+        cigar,
         r.getId,
-        r.getMappingQuality,
-        if (r.containsKey("matePosition"))
-          Some(r.getMatePosition)
+        r.getAlignment.getMappingQuality,
+        if (r.containsKey("nextMatePosition"))
+          Some(r.getNextMatePosition.getPosition)
         else
           None,
-        r.getMateReferenceSequenceName,
-        r.getName,
-        r.getOriginalBases,
-        r.getPosition,
-        r.getReadsetId,
-        r.getReferenceSequenceName,
-        r.getTags.toMap,
-        r.getTemplateLength)
+        if (r.containsKey("nextMatePosition"))
+          Some(r.getNextMatePosition.getReferenceName)
+        else
+          None,
+        r.getFragmentName,
+        r.getAlignedSequence,
+        r.getAlignment.getPosition.getPosition,
+        r.getReadGroupSetId,
+        r.getAlignment.getPosition.getReferenceName,
+        r.getInfo.toMap,
+        r.getFragmentLength)
         (readKey, read)
   }
 }
@@ -76,27 +92,26 @@ object ReadBuilder {
 class ReadsRDD(sc: SparkContext,
                applicationName: String,
                auth: Auth,
-               readsets: List[String],
-               readsPartitioner: ReadsPartitioner,
-               numRetries: Int) extends RDD[(ReadKey, Read)](sc, Nil) {
+               readGroupSetIds: List[String],
+               readsPartitioner: ReadsPartitioner)
+               extends RDD[(ReadKey, Read)](sc, Nil) {
 
   override val partitioner = Some(readsPartitioner)
 
   override def getPartitions: Array[Partition] = {
-    readsPartitioner.getPartitions(readsets)
+    readsPartitioner.getPartitions(readGroupSetIds)
   }
 
   override def compute(part: Partition, ctx: TaskContext):
     Iterator[(ReadKey, Read)] = {
-    val client = Client(applicationName, auth).genomics
-    val reads = Paginator.Reads.create(client,
-        RetryPolicy.nAttempts(numRetries))
+    val client = Client(auth).genomics
+    val reads = Paginator.Reads.create(client)
     val partition = part.asInstanceOf[ReadsPartition]
     val req = new SearchReadsRequest()
-      .setReadsetIds(partition.readsets)
-      .setSequenceName(partition.sequence)
-      .setSequenceStart(java.math.BigInteger.valueOf(partition.start))
-      .setSequenceEnd(java.math.BigInteger.valueOf(partition.end))
+      .setReadGroupSetIds(partition.readGroupSetIds)
+      .setReferenceName(partition.sequence)
+      .setStart(partition.start)
+      .setEnd(partition.end)
     reads.search(req).iterator().map(ReadBuilder.fromJavaRead(_))
   }
 }
@@ -105,7 +120,7 @@ class ReadsRDD(sc: SparkContext,
  * Defines a search range over a named sequence.
  */
 case class ReadsPartition(override val index: Int,
-                          val readsets: List[String],
+                          val readGroupSetIds: List[String],
                           val sequence: String,
                           val start: Long,
                           val end: Long) extends Partition {


### PR DESCRIPTION
Few comments on the migration:
- The flags field wasn't added back to the ReadsRDD. 
- As part of the migration utils-java was also upgraded, and the RetryPolicy removed.
- Also sneaked in a change to make applicationName='spark-examples' instead of the class name, so not every example needs to be authorized.

Fix #50 
