### PR TITLE
Refactored VariantsPcaDriver for better reuse from pyspark

### DIFF
--- a/src/main/python/variants_pca.py
+++ b/src/main/python/variants_pca.py
@@ -161,14 +161,14 @@ def pca(argv):
 
     pca_conf = (sc._jvm.com.google.cloud.genomics.spark.examples.
         PcaConf(args))
-    pca_driver = (sc._jvm.com.google.cloud.genomics.spark.examples.
-        VariantsPcaDriver(pca_conf, jsc))
+    variants_common = (sc._jvm.com.google.cloud.genomics.spark.examples.
+        VariantsCommon(pca_conf, jsc))
 
     # Map of sample ID to an index in the list of all sample IDs.
     # e.g. the list ['NA20818', 'NA20819', 'NA20826'] produces the map
     # {'NA20818': 0, 'NA20819': 1, 'NA20826', 2}
     java_id_to_index = sc._jvm.scala.collection.JavaConversions.mapAsJavaMap(
-        pca_driver.indexes())
+        variants_common.indexes())
     py_id_to_index = {}
     for k in java_id_to_index:
         py_id_to_index[k] = java_id_to_index[k]
@@ -176,7 +176,7 @@ def pca(argv):
     index_to_id = dict((v, k) for (k, v) in py_id_to_index.iteritems())
 
     # Obtain an RDD of all Variants matching PcaConf.
-    scala_rdd = pca_driver.getJavaData()
+    scala_rdd = variants_common.getJavaData()
     java_rdd = scala_rdd.toJavaRDD()
     # Convert it to Python RDD.
     py_rdd = mllib_common._java2py(sc, java_rdd)

--- a/src/main/python/variants_pca.py
+++ b/src/main/python/variants_pca.py
@@ -39,7 +39,7 @@ def prepare_call_data(py_rdd, py_id_to_index):
 
     # Obtain the callset name from the samples.
     callset_names = (samples_with_variant.
-        map(lambda callset: [c['callSetName'] for c in callset])
+        map(lambda callset: [c['callSetId'] for c in callset])
     )
 
     # Convert all names (strings) to indices (ints).

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsCommon.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsCommon.scala
@@ -1,0 +1,81 @@
+/*
+Copyright 2015 Google Inc. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package com.google.cloud.genomics.spark.examples
+
+import scala.collection.JavaConversions._
+import org.apache.spark.SparkContext
+import com.google.api.services.genomics.model.SearchCallSetsRequest
+import com.google.api.services.genomics.model.{Variant => VariantModel}
+import com.google.cloud.genomics.Authentication
+import com.google.cloud.genomics.Client
+import com.google.cloud.genomics.spark.examples.rdd.Variant
+import com.google.cloud.genomics.spark.examples.rdd.VariantKey
+import com.google.cloud.genomics.spark.examples.rdd.VariantsPartitioner
+import com.google.cloud.genomics.spark.examples.rdd.VariantsRDD
+import com.google.cloud.genomics.spark.examples.rdd.VariantsRddStats
+import com.google.cloud.genomics.utils.Paginator
+
+import org.apache.spark.rdd.RDD
+
+class VariantsCommon(conf: PcaConf, sc: SparkContext) {
+
+  private val auth = Authentication.getAccessToken(conf.clientSecrets())
+  private val ioStats = createIoStats
+
+  val (indexes, names) = {
+    val client = Client(auth).genomics
+    val searchCallsets = Paginator.Callsets.create(client)
+    val req = new SearchCallSetsRequest()
+        .setVariantSetIds(conf.variantSetId())
+    val callsets = searchCallsets.search(req).iterator().toSeq
+    val indexes = callsets.map(
+        callset => callset.getId()).toSeq.zipWithIndex.toMap
+    val names = callsets.map(
+        callset => (callset.getId(), callset.getName())).toMap
+    println(s"Matrix size: ${indexes.size}.")
+    (indexes, names)
+  }
+
+  val data = {
+    if (conf.inputPath.isDefined) {
+      List(sc.objectFile[(VariantKey, Variant)](conf.inputPath()).map(_._2))
+    } else {
+      val client = Client(auth).genomics
+      val contigs = conf.getReferences(client, conf.variantSetId()).toArray
+      val variantSets = conf.variantSetId()
+      conf.variantSetId().map { variantSetId =>
+        new VariantsRDD(sc, this.getClass.getName, auth,
+          variantSetId,
+          new VariantsPartitioner(contigs, conf.basesPerPartition()),
+          stats=ioStats).map(_._2)
+      }
+    }
+  }
+
+  def reportIoStats = {
+    this.ioStats match {
+      case Some(stats) => println(stats.toString)
+      case _ => {}
+    }
+  }
+
+  // For now assume a single dataset when invoking from python.
+  def getJavaData: RDD[VariantModel] = data.head.map(_.toJavaVariant)
+
+  def createIoStats = if (conf.inputPath.isDefined) None
+      else Option(new VariantsRddStats(sc))
+
+}


### PR DESCRIPTION
@namn @deflaux, this PR refactors VariantsPcaDriver so it is clear what is being reused from the pyspark code. ptal.