### PR TITLE
Refactor auth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ From the `spark-examples` directory run `sbt run`
 Use the following flags to match your runtime configuration:
 
 ```
+$ export SBT_OPTS='-Xbootclasspath/p:/YOUR/PATH/TO/alpn-boot-YOUR-VERSION.jar'
 $ sbt "run --help"
   -o, --output-path  <arg>
   -s, --spark-master  <arg>      A spark master URL. Leave empty if using spark-submit.
@@ -111,14 +112,7 @@ NA20828		-0.03412964005321165	-0.025991697661590686
 NA21313		-0.03401702847363714	-0.024555217139987182
 ```
 
-To save the PCA analysis output to a file, specify the `--output-path` flag.
-
-To specify a different variantset or run the analysis on multiple references use the `--variant-set-id` and  `--references` flags, the `--references` flag understand the following format, `<reference>:<start>:<end>,...`.
-
-To retrieve the results form the output directory use `gsutil`:
-```
-gsutil cat gs://<bucket-name>/<output-path>-pca.tsv/part* > pca-results.tsv
-```
+This pipeline is described in greater detail on [How do I compute principal coordinate analysis with Google Genomics?](http://googlegenomics.readthedocs.org/en/latest/use_cases/compute_principal_coordinate_analysis/index.html)
 
 ### Debugging 
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@ The projects in this repository demonstrate working with genomic data accessible
 Getting Started
 ---------------
 
- 1. Follow the [sign up instructions](https://cloud.google.com/genomics/install-genomics-tools#authenticate) and download the `client_secrets.json` file. This file can be copied to the _spark-examples_ directory.
+ 1. Download and install [Apache Spark](https://spark.apache.org/downloads.html).
 
- 2. Download and install [Apache Spark](https://spark.apache.org/downloads.html).
+ 2. If needed, install [SBT](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html)
 
- 3. If needed, install [SBT](http://www.scala-sbt.org/release/docs/Getting-Started/Setup.html)
+ 3. This project now includes code for calling the Genomics API using <a href="http://www.grpc.io">gRPC</a>.  To use gRPC, you'll need a version of ALPN that matches your JRE version. See the
+<a href="http://www.eclipse.org/jetty/documentation/9.2.10.v20150310/alpn-chapter.html">ALPN documentation</a> for a table of which ALPN JAR to use.
 
 Local Run
 ---------
@@ -25,7 +26,6 @@ Use the following flags to match your runtime configuration:
 
 ```
 $ sbt "run --help"
-  -c, --client-secrets  <arg>    (default = client_secrets.json)
   -o, --output-path  <arg>
   -s, --spark-master  <arg>      A spark master URL. Leave empty if using spark-submit.
   ...
@@ -35,9 +35,8 @@ $ sbt "run --help"
 For example: 
 
 ```
-$ sbt "run --client-secrets ../client_secrets.json --spark-master local[4]"
+$ sbt "run --spark-master local[4]"
 ```
-
 
 A menu should appear asking you to pick the sample to run:
 ```
@@ -64,34 +63,28 @@ export SBT_OPTS='-XX:MaxPermSize=256m'
 Run on Google Compute Engine
 -----------------------------
 
-If you have not done so already, follow the [instructions](https://cloud.google.com/hadoop/) to setup the Google Cloud SDK and bdutil. At the end of the process you should have launched a small cluster and logged into it using `gcloud compute`.
-
-(1) Use [bdutil](https://cloud.google.com/hadoop/bdutil) to deploy the cluster with Spark enabled.  **bdutil version 1.2.1 or higher is required. (see the setup instructions [here](http://googlegenomics.readthedocs.org/en/latest/use_cases/compute_principal_coordinate_analysis/index.html#id4)).**
+(1) Build the assembly.
 ```
-./bdutil -e extensions/spark/spark_env.sh deploy
+sbt assembly
 ```
-(2) Copy your ``client_secrets.json`` to the master.
+(2) Deploy your Spark cluster using [Google Cloud Dataproc](https://cloud.google.com/dataproc/).
 ```
-gcloud compute copy-files client_secrets.json hadoop-m:~/
+gcloud beta dataproc clusters create example-cluster --scopes cloud-platform
 ```
 (3) Copy the assembly jar to the master node.
 ```
 gcloud compute copy-files \
-  target/scala-2.10/googlegenomics-spark-examples-assembly-1.0.jar  hadoop-m:~/
+  target/scala-2.10/googlegenomics-spark-examples-assembly-1.0.jar  example-cluster-m:~/
 ```
 (4) ssh to the master.
 ```
-gcloud compute ssh hadoop-m
+gcloud compute ssh example-cluster-m
 ```
 (5) Run one of the examples.
 ```
 spark-submit --class com.google.cloud.genomics.spark.examples.SearchReadsExample1 \
-  --master spark://hadoop-m:7077 googlegenomics-spark-examples-assembly-1.0.jar \
-  --client-secrets client_secrets.json
+  googlegenomics-spark-examples-assembly-1.0.jar
 ```
-
-When prompted copy the authentication URL to a browser, authorize the application and copy 
-the authorization code. This step will copy the access token to all the workers.
 
 ### Running PCA variant analysis on GCE
 To run the [variant PCA analysis](https://github.com/googlegenomics/spark-examples/blob/master/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsPca.scala) on GCE  make sure you have followed all the steps on the previous section and that you are able to run at least one of the examples.
@@ -99,8 +92,7 @@ To run the [variant PCA analysis](https://github.com/googlegenomics/spark-exampl
 Run the example PCA analysis for BRCA1 on the [1000 Genomes Project dataset](https://cloud.google.com/genomics/data/1000-genomes).
 ```
 spark-submit --class com.google.cloud.genomics.spark.examples.VariantsPcaDriver \
-  --master spark://hadoop-m:7077 googlegenomics-spark-examples-assembly-1.0.jar \
-  --client-secrets client_secrets.json
+  googlegenomics-spark-examples-assembly-1.0.jar
 ```
 
 The analysis will output the two principal components for each sample to the console. Here is an example of the last few lines.
@@ -123,58 +115,11 @@ To save the PCA analysis output to a file, specify the `--output-path` flag.
 
 To specify a different variantset or run the analysis on multiple references use the `--variant-set-id` and  `--references` flags, the `--references` flag understand the following format, `<reference>:<start>:<end>,...`.
 
-To run a genome wide analysis on 1K genomes on a reasonable time, make sure you are running on at least 40 cores (`10 n1-standard-4 machines + 1 master`), the following command will run in approximatey 2 hours:
-
-```
-spark-submit --class com.google.cloud.genomics.spark.examples.VariantsPcaDriver \
-  --master spark://hadoop-m:7077 \
-  --conf spark.shuffle.spill=true \
-  googlegenomics-spark-examples-assembly-1.0.jar \
-  --client-secrets client_secrets.json \
-  --bases-per-partition 1000000 \
-  --num-reduce-partitions 500 \
-  --all-references \
-  --output-path 1000genomes
-```
-
-You can track the progress of the job in the Spark UI console (see the following section to make sure you can connect to the UI using your browser) .
-
 To retrieve the results form the output directory use `gsutil`:
-
 ```
 gsutil cat gs://<bucket-name>/<output-path>-pca.tsv/part* > pca-results.tsv
 ```
 
 ### Debugging 
 
-To debug the jobs from the Spark web UI, either setup a SOCKS5 proxy (recommended)
-or open the web UI ports on your instances.
-
-To use your SOCKS5 proxy with port 12345 on Firefox:
-
-```
-bdutil socksproxy 12345
-Go to Edit -> Preferences -> Advanced -> Network -> Settings
-Enable "Manual proxy configuration" with a SOCKS host "localhost" on port 12345
-Force the DNS resolution to occur on the remote proxy host rather than locally.
-Go to "about:config" in the URL bar
-Search for "socks" to toggle "network.proxy.socks_remote_dns" to "true".
-Visit the web UIs exported by your cluster!
-http://hadoop-m:8080 for Spark
-```
-
-To open the web UI ports.
-
-```
-gcloud compute firewall-rules create allow-spark-console-8080 \
-  --target-tag spark-console \
-  --description "Incoming 8080-8081 allowed." --allow tcp:8080-8081
-gcloud compute firewall-rules create allow-spark-console-4040 \
-  --target-tag spark-console \
-  --description "Incoming 4040 allowed." --allow tcp:4040
-```
-From the [developers console](https://console.developers.google.com/project),
-add the `spark-console` tag to the master and worker instances or follow the instructions
-[here](https://cloud.google.com/compute/docs/instances#tags) to do it from the command line.
-
-Then point the browser to `http://<master-node-public-ip>:8080`
+For more information, see https://cloud.google.com/dataproc/faq

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ scalacOptions += "-target:jvm-1.7"
 
 val sparkVersion = "1.3.1"
 
-val genomicsUtilsVersion = "v1beta2-0.37"
+val genomicsUtilsVersion = "v1beta2-0.38"
 
 ivyScala := ivyScala.value map { _.copy(overrideScalaVersion = true) }
 

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/GenomicsConf.scala
@@ -25,17 +25,19 @@ import org.rogach.scallop.ScallopConf
 import com.google.cloud.genomics.spark.examples.rdd.AllReferencesVariantsPartitioner
 import com.google.cloud.genomics.spark.examples.rdd.ReferencesVariantsPartitioner
 import com.google.cloud.genomics.spark.examples.rdd.VariantsPartitioner
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth
+import com.google.cloud.genomics.utils.OfflineAuth
 import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter
 
 class GenomicsConf(arguments: Seq[String]) extends ScallopConf(arguments) {
-  val DEFAULT_NUMBER_OF_BASES_PER_SHARD = 100000
+  val DEFAULT_NUMBER_OF_BASES_PER_SHARD = 1000000
   val PLATINUM_GENOMES_BRCA1_REFERENCES = "chr17:41196311:41277499"
 
   val basesPerPartition = opt[Long](default =
     Some(DEFAULT_NUMBER_OF_BASES_PER_SHARD),
       descr = "Partition each reference using a fixed number of bases")
-  val clientSecrets = opt[String](default = Some("client_secrets.json"))
+  val clientSecrets = opt[String](
+    descr = "Provide the file path to client_secrets.json to use a user "
+    + "credential instead of the Application Default Credential.")
   val inputPath = opt[String]()
   val numReducePartitions = opt[Int](default = Some(10),
       descr = "Set it to a " +

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/SearchReadsExample.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/SearchReadsExample.scala
@@ -80,7 +80,7 @@ object SearchReadsExample1 {
     val sc = conf.newSparkContext(applicationName)
     Logger.getLogger("org").setLevel(Level.WARN)
     val region = Map(("11" -> (Examples.Cilantro - 1000, Examples.Cilantro + 1000)))
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val data = new ReadsRDD(sc, applicationName, accessToken,
       List(Examples.Google_Example_Readset),
       new ReadsPartitioner(region, FixedSplits(1)))
@@ -121,7 +121,7 @@ object SearchReadsExample2 {
     val chr = "21"
     val len = Examples.HumanChromosomes(chr)
     val region = Map((chr -> (1L, len)))
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val data = new ReadsRDD(sc, applicationName, accessToken,
       List(Examples.Google_Example_Readset),
       new ReadsPartitioner(region,
@@ -145,7 +145,7 @@ object SearchReadsExample3 {
     val sc = conf.newSparkContext(applicationName)
     val chr = "21"
     val region = Map((chr -> (1L, Examples.HumanChromosomes(chr))))
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val data = new ReadsRDD(sc, applicationName, accessToken,
       List(Examples.Google_Example_Readset),
       new ReadsPartitioner(region,
@@ -176,7 +176,7 @@ object SearchReadsExample4 {
     val conf = new GenomicsConf(args)
     val outPath = conf.outputPath.orElse(Option("."))()
     val applicationName = this.getClass.getName
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val sc = conf.newSparkContext(applicationName)
     val chr = "1"
     val region = Map((chr -> (100000000L, 101000000L)))

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/SearchVariantsExample.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/SearchVariantsExample.scala
@@ -45,7 +45,7 @@ object SearchVariantsExampleKlotho {
     val sc = conf.newSparkContext(applicationName)
     Logger.getLogger("org").setLevel(Level.WARN)
     val references = "chr13:33628137:33628138"
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val data = new VariantsRDD(sc,
       applicationName,
       accessToken,
@@ -93,7 +93,7 @@ object SearchVariantsExampleBRCA1 {
     val sc = conf.newSparkContext(applicationName)
     Logger.getLogger("org").setLevel(Level.WARN)
     val brca1 = "chr17:41196311:41277499"
-    val accessToken = Authentication.getAccessToken(conf.clientSecrets())
+    val accessToken = Authentication.getAccessToken(conf.clientSecrets.get)
     val data = new VariantsRDD(sc,
         this.getClass.getName,
         accessToken,

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsCommon.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/VariantsCommon.scala
@@ -32,7 +32,7 @@ import org.apache.spark.rdd.RDD
 
 class VariantsCommon(conf: PcaConf, sc: SparkContext) {
 
-  private val auth = Authentication.getAccessToken(conf.clientSecrets())
+  private val auth = Authentication.getAccessToken(conf.clientSecrets.get)
   private val ioStats = createIoStats
 
   val (indexes, names) = {

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/ReadsRDD.scala
@@ -16,18 +16,20 @@ limitations under the License.
 package com.google.cloud.genomics.spark.examples.rdd
 
 import java.util.{List => JList}
-import scala.collection.JavaConversions._
-import org.apache.spark.Partition
-import org.apache.spark.SparkContext
-import org.apache.spark.TaskContext
-import org.apache.spark.rdd.RDD
+
+import com.google.api.services.genomics.model.CigarUnit
 import com.google.api.services.genomics.model.{Read => ReadModel}
 import com.google.api.services.genomics.model.SearchReadsRequest
 import com.google.cloud.genomics.Client
 import com.google.cloud.genomics.utils.Paginator
 import com.google.cloud.genomics.utils.ShardBoundary
-import com.google.api.services.genomics.model.CigarUnit
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth
+import com.google.cloud.genomics.utils.OfflineAuth
+
+import org.apache.spark.Partition
+import org.apache.spark.SparkContext
+import org.apache.spark.TaskContext
+import org.apache.spark.rdd.RDD
+import scala.collection.JavaConversions._
 
 /**
  * A serializable version of the Read.

--- a/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
+++ b/src/main/scala/com/google/cloud/genomics/spark/examples/rdd/VariantsRDD.scala
@@ -17,29 +17,30 @@ package com.google.cloud.genomics.spark.examples.rdd
 
 import java.lang.{Double => JDouble}
 import java.util.{List => JList}
+
+import com.google.api.services.genomics.model.SearchVariantsRequest
+import com.google.cloud.genomics.Client
+import com.google.cloud.genomics.utils.Contig
+import com.google.cloud.genomics.utils.OfflineAuth
+import com.google.cloud.genomics.utils.Paginator
+import com.google.cloud.genomics.utils.ShardBoundary
+import com.google.cloud.genomics.utils.ShardUtils
+import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter
+import com.google.cloud.genomics.utils.grpc.VariantStreamIterator
+import com.google.genomics.v1.StreamVariantsRequest
+import com.google.genomics.v1.{Variant => VariantModel}
+import com.google.genomics.v1.{VariantCall => CallModel}
+import com.google.protobuf.ByteString
 import com.google.protobuf.ListValue
 import com.google.protobuf.Value
-import scala.collection.JavaConversions._
+
+import org.apache.spark.Accumulator
 import org.apache.spark.Partition
 import org.apache.spark.SparkContext
 import org.apache.spark.SparkContext._
 import org.apache.spark.TaskContext
 import org.apache.spark.rdd.RDD
-import com.google.api.services.genomics.model.SearchVariantsRequest
-import com.google.genomics.v1.{Variant => VariantModel}
-import com.google.genomics.v1.{VariantCall => CallModel}
-import com.google.cloud.genomics.Client
-import com.google.cloud.genomics.utils.Paginator
-import org.apache.spark.Accumulator
-import com.google.cloud.genomics.utils.GenomicsFactory.OfflineAuth
-import com.google.cloud.genomics.utils.Contig
-import com.google.cloud.genomics.utils.ShardBoundary
-import com.google.cloud.genomics.utils.ShardUtils
-import com.google.genomics.v1.StreamVariantsRequest
-import com.google.cloud.genomics.utils.grpc.VariantStreamIterator
-import com.google.protobuf.ListValue
-import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter
-import com.google.protobuf.ByteString
+import scala.collection.JavaConversions._
 
 /**
  * A serializable version of the Variant.


### PR DESCRIPTION
* Pipelines now use Application Default Credentials by default.
* Fixes https://github.com/googlegenomics/spark-examples/issues/64 by pointing users to Dataproc and the Genomics Cookbook.
* Bumps utils-java version.